### PR TITLE
Fix Sphinx CodeBlock location since Sphinx 4.0.0

### DIFF
--- a/sphinxcontrib_robotframework.py
+++ b/sphinxcontrib_robotframework.py
@@ -7,7 +7,7 @@ import pickle
 import robot
 import tempfile
 
-from sphinx.directives import CodeBlock
+from sphinx.directives.code import CodeBlock
 from sphinx.errors import SphinxError
 
 ROBOT_PICKLE_FILENAME = 'robotframework.pickle'


### PR DESCRIPTION
`sphinx.directives.CodeBlock` has been deprecated since [2.1.0](https://github.com/sphinx-doc/sphinx/blob/ee298ac47e10c6c3d38ac63de8bc9c6a45367839/CHANGES#L2287) and has been moved to `sphinx.directives.code.CodeBlock` since [a86346a](https://github.com/sphinx-doc/sphinx/commit/a86346aca6bf99a8920da366caaad7c47809ecce)